### PR TITLE
Make Lavalink host configurable via LavalinkHost env variable

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -48,7 +48,8 @@ public class Program
         builder.Services.AddLavalink();
         builder.Services.ConfigureLavalink(cfg =>
         {
-            cfg.BaseAddress = new Uri("http://localhost:2333");
+            var lavalinkHost = Environment.GetEnvironmentVariable("LavalinkHost") ?? "localhost";
+            cfg.BaseAddress = new Uri($"http://{lavalinkHost}:2333");
         });
         builder.Services.AddLyrics();
         builder.Services.AddInactivityTracking();


### PR DESCRIPTION
Fixes bot crash loop in Docker where localhost:2333 resolved to the bot container itself instead of the Lavalink container. Falls back to localhost for local development when the variable is not set.